### PR TITLE
Added encoding in Bulk API response

### DIFF
--- a/src/raw_dag_generator/dependencies/sfdc2bq/salesforce_to_bigquery.py
+++ b/src/raw_dag_generator/dependencies/sfdc2bq/salesforce_to_bigquery.py
@@ -337,6 +337,7 @@ class SalesforceToBigquery:
                         # because this is what's returned when the last set
                         # was retrieved in the multiple-batch situation.
                         locator = "null"
+                    result_response.encoding = 'utf-8'
                     yield result_response.iter_content(
                         chunk_size=SalesforceToBigquery._CSV_STREAM_CHUNK_SIZE_,
                         decode_unicode=True)


### PR DESCRIPTION
Encoding utf-8 has been added to handle special characters in Salesforce Bulk API Query Job response. Without this encoding, Unicode characters get corrupted while loading into BigQuery